### PR TITLE
Fix Lenis initialization to avoid mobile activation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,37 +11,70 @@ import { useEffect, useRef, useState } from "react";
 export default function Home() {
 
   const lenisRef = useRef<Lenis | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    // Detect mobile devices
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
+    const updateIsMobile = () => {
+      const isMobileDevice = window.innerWidth < 768 || "ontouchstart" in window;
+      setIsMobile(isMobileDevice);
     };
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
 
-    // Only initialize Lenis on desktop for better mobile performance
-    if (!isMobile) {
-      lenisRef.current = new Lenis({
-        duration: 1.2,
-        easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
-        touchMultiplier: 0, // Disable touch scrolling to prevent conflicts
-      })
-      window.lenis = lenisRef.current;
-
-      function raf(time: number) {
-        lenisRef.current?.raf(time);
-        requestAnimationFrame(raf);
-      }
-      requestAnimationFrame(raf);
-    }
+    updateIsMobile();
+    window.addEventListener("resize", updateIsMobile);
 
     return () => {
-      window.removeEventListener('resize', checkMobile);
-      lenisRef?.current?.destroy();
+      window.removeEventListener("resize", updateIsMobile);
     };
-  }, [isMobile])
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (isMobile) {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+
+      if (lenisRef.current) {
+        lenisRef.current.destroy();
+        lenisRef.current = null;
+      }
+
+      window.lenis = undefined;
+      return;
+    }
+
+    const lenis = new Lenis({
+      duration: 1.2,
+      easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+      touchMultiplier: 0,
+    });
+
+    lenisRef.current = lenis;
+    window.lenis = lenis;
+
+    const raf = (time: number) => {
+      lenis.raf(time);
+      animationFrameRef.current = requestAnimationFrame(raf);
+    };
+
+    animationFrameRef.current = requestAnimationFrame(raf);
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+
+      lenis.destroy();
+      lenisRef.current = null;
+      window.lenis = undefined;
+    };
+  }, [isMobile]);
 
 
   return (


### PR DESCRIPTION
## Summary
- separate mobile detection from Lenis initialization in the Home page
- prevent Lenis from running on mobile devices and ensure animation frame cleanup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfbeadcd8c8325aaccb05f9326f3f7